### PR TITLE
Add message count limit and retrieval method for users

### DIFF
--- a/DynamoDBAccessor.Tests/Services/DynamoDbServiceTest.cs
+++ b/DynamoDBAccessor.Tests/Services/DynamoDbServiceTest.cs
@@ -57,6 +57,21 @@ namespace DynamoDBAccessor.Tests.Services
         }
 
         [TestMethod]
+        public async Task GetTodayLineMessageCountAsync()
+        {
+            // Arrange
+            var userId = "test-user-id";
+
+            // Act
+            var result = await dynamoDbService.GetTodayLineMessageCountAsync(userId);
+
+            Debug.WriteLine(result);
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
         public async Task GetLineMessageByUserIDAsync()
         {
             // Arrange

--- a/DynamoDBAccessor/Interfaces/IDynamoDbService.cs
+++ b/DynamoDBAccessor/Interfaces/IDynamoDbService.cs
@@ -12,6 +12,8 @@ namespace DynamoDBAccessor.Interfaces
     {
         Task<List<LineMessage>> GetLineMessageByUserIDAsync(string userId);
 
+        Task<int> GetTodayLineMessageCountAsync(string userId);
+
         Task AddLineMessageAsync(LineMessage lineMessage);
     }
 }

--- a/DynamoDBAccessor/Services/DynamoDbService.cs
+++ b/DynamoDBAccessor/Services/DynamoDbService.cs
@@ -85,6 +85,33 @@ namespace DynamoDBAccessor.Services
             return resultList;
         }
 
+        public async Task<int> GetTodayLineMessageCountAsync(string userId)
+        {
+            // 今日の日付の0時を取得（UTCで）
+            var startOfToday = DateTime.UtcNow.Date;
+            var startOfTomorrow = startOfToday.AddDays(1);
+
+            // DynamoDBクエリのリクエスト作成
+            var queryRequest = new QueryRequest
+            {
+                TableName = "LineMessages",
+                IndexName = "UserId-EventTimestamp-index", // GSI
+                KeyConditionExpression = "UserId = :userId AND EventTimestamp BETWEEN :startOfToday AND :startOfTomorrow",
+                ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                {
+                    { ":userId", new AttributeValue { S = userId } },
+                    { ":startOfToday", new AttributeValue { N = ((DateTimeOffset)startOfToday).ToUnixTimeSeconds().ToString() } },
+                    { ":startOfTomorrow", new AttributeValue { N = ((DateTimeOffset)startOfTomorrow).ToUnixTimeSeconds().ToString() } }
+                }
+            };
+
+            // クエリ実行
+            var response = await client.QueryAsync(queryRequest);
+
+            // メッセージ数を返す
+            return response.Count;
+        }
+
         public async Task AddLineMessageAsync(LineMessage lineMessage)
         {
             await context.SaveAsync(lineMessage);

--- a/Line/appsettings.json
+++ b/Line/appsettings.json
@@ -11,6 +11,10 @@
     "ChannelAccessToken": {
       "Nagiyu": "",
       "Gyaru": ""
+    },
+    "MaxMessageCount": {
+      "Nagiyu": 0,
+      "Gyaru": 0
     }
   },
   "OpenAI": {

--- a/LineBotProcessor/Services/MessageProcessor.cs
+++ b/LineBotProcessor/Services/MessageProcessor.cs
@@ -52,6 +52,27 @@ namespace LineBotProcessor.Services
 
                     var replyToken = messageEvent.ReplyToken;
 
+                    var messageCount = await dynamoDbService.GetTodayLineMessageCountAsync(source.UserId);
+                    if (messageCount >= int.Parse(AppSettings.GetSetting("LineSettings:MaxMessageCount:Nagiyu")))
+                    {
+                        var payload = new ReplyRequest
+                        {
+                            ReplyToken = replyToken,
+                            Messages = new List<ReplyMessage>
+                            {
+                                new ReplyMessage
+                                {
+                                    Type = "text",
+                                    Text = "今日の会話上限に達しました。また明日ご利用ください！"
+                                }
+                            }
+                        };
+
+                        await apiHandler.SendReplyAsync(payload);
+
+                        continue;
+                    }
+
                     if (messageEvent.Message.Type == "text")
                     {
                         var textMessage = JsonHelper.Deserialize<WebhookRequest<MessageEvent<TextMessage>>>(requestBody).Events[index].Message;
@@ -156,6 +177,27 @@ namespace LineBotProcessor.Services
                     var messageEvent = JsonHelper.Deserialize<WebhookRequest<MessageEvent<MessageBase>>>(requestBody).Events[index];
 
                     var replyToken = messageEvent.ReplyToken;
+
+                    var messageCount = await dynamoDbService.GetTodayLineMessageCountAsync(source.UserId);
+                    if (messageCount >= int.Parse(AppSettings.GetSetting("LineSettings:MaxMessageCount:Gyaru")))
+                    {
+                        var payload = new ReplyRequest
+                        {
+                            ReplyToken = replyToken,
+                            Messages = new List<ReplyMessage>
+                            {
+                                new ReplyMessage
+                                {
+                                    Type = "text",
+                                    Text = "今日のトークはもうMAXいっちゃったわ💦また明日話そ〜ねん💕"
+                                }
+                            }
+                        };
+
+                        await apiHandler.SendReplyAsync(payload);
+
+                        continue;
+                    }
 
                     if (messageEvent.Message.Type == "text")
                     {


### PR DESCRIPTION
Introduce a method to retrieve today's message count for users and implement a limit for Nagiyu and Gyaru users in the message processing logic.