### PR TITLE
Improve case-insensitive retrieval of webhook signature

### DIFF
--- a/LineBridge.Core/Services/Webhook/WebhookBase.cs
+++ b/LineBridge.Core/Services/Webhook/WebhookBase.cs
@@ -76,7 +76,7 @@ namespace LineBridge.Core.Services.Webhook
         public async Task HandleWebhookEvent(IDictionary<string, StringValues> headers, string requestBody)
         {
 #if !DEBUG
-            var xLineSignature = headers["X-Line-Signature"];
+            var xLineSignature = headers.Keys.FirstOrDefault(key => string.Equals(key, "X-Line-Signature", StringComparison.OrdinalIgnoreCase));
 
             if (!ValidateLineSignature(requestBody, xLineSignature))
             {


### PR DESCRIPTION
Enhance the retrieval of the webhook signature to be case-insensitive, ensuring more robust handling of header keys.