### PR TITLE
Fix issue #58: デプロイの発火条件変更

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request fixes #58.

The changes added the paths-ignore: ['.github/**'] setting to the push triggers in both .github/workflows/deploy.yml and .github/workflows/deploy-develop.yml. This configuration ensures that pushes which only modify files under the .github directory (including workflow files themselves) will not trigger the deploy workflows. This directly addresses the requirement that changes under .github should not cause the deploy workflows to run. The solution is correct and sufficient based on a static check of the workflow files.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌